### PR TITLE
Check if multi-site network and don't run plugin; replace notice coun…

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="" />
+</component>

--- a/.idea/lil-notices.iml
+++ b/.idea/lil-notices.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/lil-notices.iml" filepath="$PROJECT_DIR$/.idea/lil-notices.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="ed6e4651-2eb5-4e76-a11d-bc876936cdc4" name="Default" comment="" />
+    <ignored path="lil-notices.iws" />
+    <ignored path=".idea/workspace.xml" />
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="TRACKING_ENABLED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="CreatePatchCommitExecutor">
+    <option name="PATCH_PATH" value="" />
+  </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="default_target" />
+  <component name="FavoritesManager">
+    <favorites_list name="lil-notices" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="JsBuildToolGruntFileManager" detection-done="true" sorting="DEFINITION_ORDER" />
+  <component name="JsBuildToolPackageJson" detection-done="true" sorting="DEFINITION_ORDER" />
+  <component name="JsGulpfileManager">
+    <detection-done>true</detection-done>
+    <sorting>DEFINITION_ORDER</sorting>
+  </component>
+  <component name="PhpWorkspaceProjectConfiguration" backward_compatibility_performed="true" interpreter_name="PHP 5.5" />
+  <component name="ProjectFrameBounds">
+    <option name="x" value="900" />
+    <option name="y" value="23" />
+    <option name="width" value="1617" />
+    <option name="height" value="1417" />
+  </component>
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+      <flattenPackages />
+      <showMembers />
+      <showModules />
+      <showLibraryContents />
+      <hideEmptyPackages />
+      <abbreviatePackageNames />
+      <autoscrollToSource />
+      <autoscrollFromSource />
+      <sortByType />
+      <manualOrder />
+      <foldersAlwaysOnTop value="true" />
+    </navigator>
+    <panes>
+      <pane id="Scratches" />
+      <pane id="ProjectPane">
+        <subPane>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="lil-notices" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+          </PATH>
+        </subPane>
+      </pane>
+      <pane id="Scope" />
+    </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="settings.editor.selected.configurable" value="reference.webide.settings.project.settings.php" />
+    <property name="settings.editor.splitter.proportion" value="0.2" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+  </component>
+  <component name="ShelveChangesManager" show_recycled="false">
+    <option name="remove_strategy" value="false" />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="ed6e4651-2eb5-4e76-a11d-bc876936cdc4" name="Default" comment="" />
+      <created>1474478308968</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1474478308968</updated>
+      <workItem from="1474478310097" duration="18000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TimeTrackingManager">
+    <option name="totallyTimeSpent" value="18000" />
+  </component>
+  <component name="ToolWindowManager">
+    <frame x="900" y="23" width="1617" height="1417" extended-state="0" />
+    <editor active="false" />
+    <layout>
+      <window_info id="GfmBrowser" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Project" active="true" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.2495238" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
+      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="true" content_ui="tabs" />
+      <window_info id="Database" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="true" content_ui="tabs" />
+      <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
+      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
+      <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+    </layout>
+  </component>
+  <component name="Vcs.Log.UiProperties">
+    <option name="RECENTLY_FILTERED_USER_GROUPS">
+      <collection />
+    </option>
+    <option name="RECENTLY_FILTERED_BRANCH_GROUPS">
+      <collection />
+    </option>
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager />
+    <watches-manager />
+  </component>
+</project>

--- a/assets/dist/main.js
+++ b/assets/dist/main.js
@@ -1,5 +1,19 @@
 jQuery( document ).ready( function( $ ) {
 
+	var count = $("#wp-admin-bar-ln_all_notices ul li").length;
+	if ( count >= 0 ) {
+		$( "#wp-admin-bar-ln_menu" ).prepend( "<span class='ln-notifications'>" + count + "</span>" );
+	}
+
+	if ( count == 0 ) {
+		$( "li#wp-admin-bar-ln_menu" ).addClass( "zero-count" );
+	}
+
+	$(".ln-notice-item div").replaceWith(function() {
+		var msgclass = $( this ).attr('class');
+		return "<span class='" + msgclass + "' >" + this.innerHTML + "</span>";
+	});
+
 	// we only need to add the click/remove the hover when we're not on "mobile"
 	if ( false == $( 'body' ).hasClass( 'mobile' ) ) {
 
@@ -13,15 +27,17 @@ jQuery( document ).ready( function( $ ) {
 			e.preventDefault();
 			$( '#wp-admin-bar-ln_menu' ).toggleClass( 'hover' );
 		} );
+
+		$( '#wp-admin-bar-ln_menu>span' ).on( 'hover', function(e) {
+			return false;
+		});
+
+		// add a click event to the span
+		$( '#wp-admin-bar-ln_menu>span' ).on( 'click', function(e) {
+			e.preventDefault();
+			$( '#wp-admin-bar-ln_menu' ).toggleClass( 'hover' );
+		} );
 	}
 
-	var count = $("#wp-admin-bar-ln_all_notices ul li").length;
-	if ( count >= 0 ) {
-		$( "#wp-admin-bar-ln_menu > a" ).prepend( "<span class='ln-notifications'>" + count + "" );
-	}
-
-	if ( count == 0 ) {
-		$( "li#wp-admin-bar-ln_menu" ).addClass( "zero-count" );
-	}
 
 } );

--- a/assets/dist/main.js
+++ b/assets/dist/main.js
@@ -16,7 +16,12 @@ jQuery( document ).ready( function( $ ) {
 	}
 
 	var count = $("#wp-admin-bar-ln_all_notices ul li").length;
-	if ( count > 0 ) {
+	if ( count >= 0 ) {
 		$( "#wp-admin-bar-ln_menu > a" ).prepend( "<span class='ln-notifications'>" + count + "" );
 	}
+
+	if ( count == 0 ) {
+		$( "li#wp-admin-bar-ln_menu" ).addClass( "zero-count" );
+	}
+
 } );

--- a/assets/dist/main.js
+++ b/assets/dist/main.js
@@ -15,4 +15,7 @@ jQuery( document ).ready( function( $ ) {
 		} );
 	}
 
+	var count = $("#wp-admin-bar-ln_all_notices ul li").length;
+	$( "#wp-admin-bar-ln_menu > a" ).prepend( "<span class='ln-notifications'>" + count + "" );
+
 } );

--- a/assets/dist/main.js
+++ b/assets/dist/main.js
@@ -16,6 +16,7 @@ jQuery( document ).ready( function( $ ) {
 	}
 
 	var count = $("#wp-admin-bar-ln_all_notices ul li").length;
-	$( "#wp-admin-bar-ln_menu > a" ).prepend( "<span class='ln-notifications'>" + count + "" );
-
+	if ( count > 0 ) {
+		$( "#wp-admin-bar-ln_menu > a" ).prepend( "<span class='ln-notifications'>" + count + "" );
+	}
 } );

--- a/assets/dist/style.css
+++ b/assets/dist/style.css
@@ -65,7 +65,7 @@
 
 #wpadminbar #wp-admin-bar-ln_menu .ln-notifications {
 	color: #ffffff;
-	background: #d46f15;
+	background-color: #d46f15;
 	padding: 2px 8px;
 	display: inline-block;
 	font-size: 9px;
@@ -74,3 +74,28 @@
 	margin-right: 4px;
 	border-radius: 10px;
 }
+
+#wpadminbar #wp-admin-bar-ln_menu .ln-notifications {
+	color: #ffffff;
+	background-color: #d46f15;
+	padding: 2px 8px;
+	display: inline-block;
+	font-size: 9px;
+	line-height: 17px;
+	font-weight: 600;
+	margin-right: 4px;
+	border-radius: 10px;
+}
+
+#wpadminbar #wp-admin-bar-ln_menu.zero-count .ln-notifications {
+	background-color: #808080;
+}
+
+#wpadminbar #wp-admin-bar-ln_menu.zero-count .ab-sub-wrapper {
+	display: none;
+}
+
+/*TODO: Change cursor to pointer when count is zero*/
+/*#wpadminbar #wp-admin-bar-ln_menu.zero-count a.ab-item {*/
+	/*cursor: pointer;*/
+/*}*/

--- a/assets/dist/style.css
+++ b/assets/dist/style.css
@@ -10,7 +10,7 @@
 #wp-toolbar > ul > #wp-admin-bar-ln_menu #wp-admin-bar-ln_all_notices {
 	background: #ffffff;
 	color: #0a0a0e;
-	width: 600px;
+	width: 800px;
 }
 
 @media screen and ( max-width: 800px ) {
@@ -26,29 +26,40 @@
 	padding: 10px;
 }
 
-#wpadminbar .ln-notice {
+#wpadminbar .ln-notice-item > * {
+	background-color: #f7f7f7;
+	padding: 10px 20px;
+}
+
+#wpadminbar .ln-notice-item {
 	margin: 5px 0;
 }
 
-#wpadminbar #wp-admin-bar-ln_menu-default .ln-notice > div > p {
+#wpadminbar #wp-admin-bar-ln_menu-default .ln-notice-item > div > p {
 	line-height: 12px !important;
 }
 
-#wpadminbar .quicklinks .ln-notice a {
+#wpadminbar .quicklinks .menupop ul li .ln-notice-item a {
 	display: inline;
 	padding: 0;
+	color: #0096dd;
+	height: 15px;
 }
 
-#wpadminbar .ln-notice > div {
-	padding: 0 20px;
-}
-
-#wpadminbar .ln-updated {
+#wpadminbar .ln-updated, #wpadminbar .ln-notice.notice-success {
 	border-left: 4px solid #46b450;
 }
 
-#wpadminbar .quicklinks #wp-admin-bar-ln_menu a {
-	display: inline-block;
+#wpadminbar .ln-notice.notice-warning {
+	border-left: 4px solid #ffb900;
+}
+
+#wpadminbar .ln-notice.notice-error {
+	border-left: 4px solid #dc3232;
+}
+
+#wpadminbar .ln-notice.notice-info {
+	border-left: 4px solid #00a0d2;
 }
 
 #wpadminbar #wp-admin-bar-ln_menu .ln-notifications {

--- a/assets/dist/style.css
+++ b/assets/dist/style.css
@@ -19,12 +19,6 @@
 	}
 }
 
-@media screen and (max-width: 400px) {
-	#wpadminbar #wp-admin-bar-ln_menu > a {
-		display: none;
-	}
-}
-
 #wpadminbar .ln-notice-list {
 	padding: 10px;
 }
@@ -73,7 +67,13 @@
 	border-left: 4px solid #00a0d2;
 }
 
-@media screen and (min-width: 400px) {
+@media screen and (max-width: 420px) {
+	#wpadminbar #wp-admin-bar-ln_menu > a {
+		display: none;
+	}
+}
+
+@media screen and (min-width: 420px) {
 	#wpadminbar #wp-admin-bar-ln_menu > a {
 		display: inline-block;
 	}
@@ -98,7 +98,7 @@
 	border-radius: 10px;
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (max-width: 420px) {
 	#wpadminbar #wp-admin-bar-ln_menu .ln-notifications {
 		margin-top: 12px;
 	}

--- a/assets/dist/style.css
+++ b/assets/dist/style.css
@@ -1,15 +1,64 @@
-#wp-toolbar>ul>#wp-admin-bar-ln_menu .ab-empty-item {
+#wp-toolbar > ul > #wp-admin-bar-ln_menu .ab-empty-item {
 	display: none;
 }
-#wp-toolbar>ul>#wp-admin-bar-ln_menu {
-	display: block;
+
+#wp-toolbar > ul > #wp-admin-bar-ln_menu {
+	display: inline-block;
 	position: static;
 }
 
-#wp-toolbar>ul>#wp-admin-bar-ln_menu #wp-admin-bar-ln_all_notices {
+#wp-toolbar > ul > #wp-admin-bar-ln_menu #wp-admin-bar-ln_all_notices {
 	background: #ffffff;
 	color: #0a0a0e;
+	width: 600px;
+}
+
+@media screen and ( max-width: 800px ) {
+	#wp-toolbar > ul > #wp-admin-bar-ln_menu #wp-admin-bar-ln_all_notices {
+		width: 100%;
+	}
 }
 
 #wp-toolbar>ul>#wp-admin-bar-ln_menu.menupop.ab-sub-wrapper {
+}
+
+#wpadminbar .ln-notice-list {
+	padding: 10px;
+}
+
+#wpadminbar .ln-notice {
+	margin: 5px 0;
+}
+
+#wpadminbar #wp-admin-bar-ln_menu-default .ln-notice > div > p {
+	line-height: 12px !important;
+}
+
+#wpadminbar .quicklinks .ln-notice a {
+	display: inline;
+	padding: 0;
+}
+
+#wpadminbar .ln-notice > div {
+	padding: 0 20px;
+}
+
+#wpadminbar .ln-updated {
+	border-left: 4px solid #46b450;
+}
+
+#wpadminbar .quicklinks #wp-admin-bar-ln_menu a {
+	display: inline-block;
+}
+
+#wpadminbar #wp-admin-bar-ln_menu .ln-notifications {
+	color: #ffffff;
+	background: #d46f15;
+	padding: 2px 8px;
+	display: inline-block;
+	font-size: 9px;
+	line-height: 17px;
+	font-weight: 600;
+	margin-right: 4px;
+	border-radius: 10px;
 }

--- a/assets/dist/style.css
+++ b/assets/dist/style.css
@@ -19,6 +19,12 @@
 	}
 }
 
+@media screen and (max-width: 400px) {
+	#wpadminbar #wp-admin-bar-ln_menu > a {
+		display: none;
+	}
+}
+
 #wpadminbar .ln-notice-list {
 	padding: 10px;
 }
@@ -36,15 +42,19 @@
 	display: block;
 }
 
-#wpadminbar #wp-admin-bar-ln_menu-default .ln-notice-item > div > p {
-	line-height: 12px !important;
+.ln-notice-item > span {
+	display: block;
+}
+
+#wpadminbar #wp-admin-bar-ln_menu-default .ln-notice-item > span > p {
+	line-height: 24px !important;
 }
 
 #wpadminbar .quicklinks .menupop ul li .ln-notice-item a {
 	display: inline;
 	padding: 0;
 	color: #0096dd;
-	height: 15px;
+	line-height: 24px !important;
 }
 
 #wpadminbar .ln-updated, #wpadminbar .ln-notice-item .notice-success {
@@ -63,16 +73,16 @@
 	border-left: 4px solid #00a0d2;
 }
 
-#wpadminbar #wp-admin-bar-ln_menu .ln-notifications {
-	color: #ffffff;
-	background-color: #d46f15;
-	padding: 2px 8px;
-	display: inline-block;
-	font-size: 9px;
-	line-height: 17px;
-	font-weight: 600;
-	margin-right: 4px;
-	border-radius: 10px;
+@media screen and (min-width: 400px) {
+	#wpadminbar #wp-admin-bar-ln_menu > a {
+		display: inline-block;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	#wpadminbar .quicklinks #wp-admin-bar-ln_menu a {
+		padding: 0 7px 0 6px;
+	}
 }
 
 #wpadminbar #wp-admin-bar-ln_menu .ln-notifications {
@@ -83,8 +93,15 @@
 	font-size: 9px;
 	line-height: 17px;
 	font-weight: 600;
-	margin-right: 4px;
+	margin-right: 0;
+	margin-top: 0;
 	border-radius: 10px;
+}
+
+@media screen and (max-width: 400px) {
+	#wpadminbar #wp-admin-bar-ln_menu .ln-notifications {
+		margin-top: 12px;
+	}
 }
 
 #wpadminbar #wp-admin-bar-ln_menu.zero-count .ln-notifications {

--- a/assets/dist/style.css
+++ b/assets/dist/style.css
@@ -19,9 +19,6 @@
 	}
 }
 
-#wp-toolbar>ul>#wp-admin-bar-ln_menu.menupop.ab-sub-wrapper {
-}
-
 #wpadminbar .ln-notice-list {
 	padding: 10px;
 }
@@ -35,6 +32,10 @@
 	margin: 5px 0;
 }
 
+#wpadminbar .ln-notice-item .update-nag {
+	display: block;
+}
+
 #wpadminbar #wp-admin-bar-ln_menu-default .ln-notice-item > div > p {
 	line-height: 12px !important;
 }
@@ -46,19 +47,19 @@
 	height: 15px;
 }
 
-#wpadminbar .ln-updated, #wpadminbar .ln-notice.notice-success {
+#wpadminbar .ln-updated, #wpadminbar .ln-notice-item .notice-success {
 	border-left: 4px solid #46b450;
 }
 
-#wpadminbar .ln-notice.notice-warning {
+#wpadminbar .ln-notice-item .notice-warning {
 	border-left: 4px solid #ffb900;
 }
 
-#wpadminbar .ln-notice.notice-error {
+#wpadminbar .ln-notice-item .notice-error, #wpadminbar .ln-notice-item .ln-error {
 	border-left: 4px solid #dc3232;
 }
 
-#wpadminbar .ln-notice.notice-info {
+#wpadminbar .ln-notice-item .notice-info {
 	border-left: 4px solid #00a0d2;
 }
 

--- a/class-lil-notices.php
+++ b/class-lil-notices.php
@@ -65,22 +65,27 @@ if ( ! class_exists( 'Lil_Notices' ) ) {
 		 */
 		public static function notices_content() {
 			global $wp_filter;
-			// count the number of items attached to 'admin_notices'
+			// count the number of items attached to 'admin_notices' and 'all_admin_notices'
 			// might actually just pull each item from this bit as it will make more sense
 			$html = '';
-			if ( empty( $wp_filter['admin_notices'] ) ) {
+			if ( empty( $wp_filter['admin_notices'] ) && empty( $wp_filter['all_admin_notices']) ) {
 				$html .= apply_filters( 'ln_no_notices', __( 'Nothing to see here!', 'ln_domain' ) );
 			} else {
 				$html .= '<ul class="ln-notice-list">';
 
 				ob_start();
 				static::do_action( 'admin_notices' );
+				static::do_action( 'all_admin_notices' );
 				$notices = ob_get_clean();
 
 				// preg match & replace the classes that WP is using to move admin notices in under the page's H tag
 				$notices = preg_replace(
 					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(updated)([A-Za-z0-9\-\_\ ]*)([\"\'])/',
-					'$1$2 ln-updated $4$5', $notices );
+					'$1$2ln-updated $4$5', $notices );
+
+				$notices = preg_replace(
+					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(notice[^\-\_])([A-Za-z0-9\-\_\ ]*)([\"\'])/',
+					'$1$2ln-notice $4$5', $notices );
 
 				$html .= $notices;
 
@@ -89,6 +94,7 @@ if ( ! class_exists( 'Lil_Notices' ) ) {
 
 			// since we're grabbing them above, remove the core do_action via remove_all_actions
 			remove_all_actions( 'admin_notices' );
+			remove_all_actions( 'all_admin_notices' );
 
 			return $html;
 		}
@@ -160,7 +166,7 @@ if ( ! class_exists( 'Lil_Notices' ) ) {
 						$the_item = ob_get_clean();
 
 						if ( false != $the_item ) {
-							echo '<li class="ln-notice" data-notice-id="' . sanitize_key( $the_['function'] ) . '">';
+							echo '<li class="ln-notice-item" data-notice-id="' . sanitize_key( $the_['function'] ) . '">';
 							echo $the_item;
 							echo '</li>';
 						}

--- a/class-lil-notices.php
+++ b/class-lil-notices.php
@@ -2,7 +2,7 @@
 /**
  * Lil Notices Plugin Class
  *
- * @since 0.1
+ * @since 0.1.2
  */
 
 //avoid direct calls to this file, because now WP core and framework has been used
@@ -22,14 +22,14 @@ if ( ! class_exists( 'Lil_Notices' ) ) {
 		 * @return  void
 		 */
 		public static function init() {
-			add_action( 'admin_init', array( get_called_class(), 'admin_init' ), 1 );
+			if ( ( is_multisite() ) && ( is_network_admin () ) ) {
+				return;
+			}
 			add_action( 'admin_bar_menu', array( get_called_class(), 'admin_bar_menu' ), 999 );
 			add_action( 'admin_enqueue_scripts', array( get_called_class(), 'admin_enqueue_scripts' ), 999 );
 		} // end public function init
 
-		public static function admin_init() {
-		}
-		
+
 		public static function admin_enqueue_scripts() {
 			wp_enqueue_script( 'ln-scripts', plugin_dir_url( __FILE__ ) . 'assets/dist/main.js', array(), LIL_NOTICES__VERSION, true );
 			wp_enqueue_style( 'ln-styles', plugin_dir_url( __FILE__ ) . 'assets/dist/style.css', array(), LIL_NOTICES__VERSION );
@@ -71,7 +71,6 @@ if ( ! class_exists( 'Lil_Notices' ) ) {
 			if ( empty( $wp_filter['admin_notices'] ) ) {
 				$html .= apply_filters( 'ln_no_notices', __( 'Nothing to see here!', 'ln_domain' ) );
 			} else {
-				$html .= 'Count: ' . count( $wp_filter['admin_notices'] ) . '<hr>';
 				$html .= '<ul class="ln-notice-list">';
 
 				ob_start();

--- a/class-lil-notices.php
+++ b/class-lil-notices.php
@@ -81,15 +81,15 @@ if ( ! class_exists( 'Lil_Notices' ) ) {
 				// preg match & replace the classes that WP is using to move admin notices in under the page's H tag
 				$notices = preg_replace(
 					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(updated)([A-Za-z0-9\-\_\ ]*)([\"\'])/',
-					'$1$2ln-updated$4$5', $notices );
+					'$1$2ln-updated $4$5', $notices );
 
 				$notices = preg_replace(
 					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(notice[^\-\_])([A-Za-z0-9\-\_\ ]*)([\"\'])/',
-					'$1$2ln-notice$4$5', $notices );
+					'$1$2ln-notice $4$5', $notices );
 
 				$notices = preg_replace(
 					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(error)([A-Za-z0-9\-\_\ ]*)([\"\'])/',
-					'$1$2ln-error$4$5', $notices );
+					'$1$2ln-error $4$5', $notices );
 
 				$html .= $notices;
 

--- a/class-lil-notices.php
+++ b/class-lil-notices.php
@@ -81,11 +81,15 @@ if ( ! class_exists( 'Lil_Notices' ) ) {
 				// preg match & replace the classes that WP is using to move admin notices in under the page's H tag
 				$notices = preg_replace(
 					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(updated)([A-Za-z0-9\-\_\ ]*)([\"\'])/',
-					'$1$2ln-updated $4$5', $notices );
+					'$1$2ln-updated$4$5', $notices );
 
 				$notices = preg_replace(
 					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(notice[^\-\_])([A-Za-z0-9\-\_\ ]*)([\"\'])/',
-					'$1$2ln-notice $4$5', $notices );
+					'$1$2ln-notice$4$5', $notices );
+
+				$notices = preg_replace(
+					'/(class=[\'\"])([A-Za-z0-9\-\_\ ]*)(error)([A-Za-z0-9\-\_\ ]*)([\"\'])/',
+					'$1$2ln-error$4$5', $notices );
 
 				$html .= $notices;
 

--- a/lil-notices.php
+++ b/lil-notices.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://mlteal.com/
  * Description: Giant admin notices are annoying. Make them lil'.
  * Author: mlteal
- * Version: 0.1
+ * Version: 0.1.2
  * License: GPLv2
  * Text Domain: ln_domain
  *
@@ -15,7 +15,7 @@
  * @category plugin
  */
 
-define( 'LIL_NOTICES__VERSION', '0.1' );
+define( 'LIL_NOTICES__VERSION', '0.1.2' );
 
 require_once( 'class-lil-notices.php' );
 

--- a/lil-notices.php
+++ b/lil-notices.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://mlteal.com/
  * Description: Giant admin notices are annoying. Make them lil'.
  * Author: mlteal
- * Version: 0.1.2
+ * Version: 0.1.3
  * License: GPLv2
  * Text Domain: ln_domain
  *
@@ -15,7 +15,7 @@
  * @category plugin
  */
 
-define( 'LIL_NOTICES__VERSION', '0.1.2' );
+define( 'LIL_NOTICES__VERSION', '0.1.3' );
 
 require_once( 'class-lil-notices.php' );
 

--- a/lil-notices.php
+++ b/lil-notices.php
@@ -4,11 +4,11 @@
  * Plugin URI: http://mlteal.com/
  * Description: Giant admin notices are annoying. Make them lil'.
  * Author: mlteal
- * Version: 0.1.3
+ * Version: 1.0
  * License: GPLv2
  * Text Domain: ln_domain
  *
- * GitHub Plugin URI: https://github.com/
+ * GitHub Plugin URI: https://github.com/mlteal/lil-notices
  * GitHub Branch: master
  *
  * @package ln_domain


### PR DESCRIPTION
#### CHANGELOG BULLETS
- Don't run plugin on network admin screen
- Replace admin notice counter with JS counter
- Add markup and styles for number of notices in admin menu bar
- Style notices list content
- Mobile styles
- Catch admin notices hooked into all_admin_notices
#### MODIFIES
- Admin front-end
- function
#### READY FOR PRODUCTION
- [x] Pull Request Form (this)
- [x] No remaining **PHP** `error_log()` or **JavaScript** `console.log()` functions in code.
- [x] No **PHP** Errors, Warnings or Notices _(in error log, `WP_DEBUG`, etc)_.
- [x] No compiled/minified scripts or styles committed _(i.e. main.js, style.css)_
- [x] Clean code, best practices and [WordPress Development Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
